### PR TITLE
Fix docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,14 +13,14 @@ Sentry helpers:
 
 
 fillmore.scrubber
-================
+=================
 
 .. automodule:: fillmore.scrubber
    :members:
 
 
 fillmore.libsentry
-=================
+==================
 
 .. automodule:: fillmore.libsentry
    :members:

--- a/src/fillmore/libsentry.py
+++ b/src/fillmore/libsentry.py
@@ -30,11 +30,11 @@ def set_up_sentry(
     (https://docs.sentry.io/platforms/python/configuration/integrations/default-integrations/),
     but not the auto-enabling ones.
 
-    :arg sentry_dsn: the Sentry DSN
-    :arg release: the release name to tag events with
-    :arg host_id: some str representing the host this service is running on
-    :arg integrations: list of sentry integrations to set up;
-    :arg before_send: set this to a callable to handle the Sentry before_send hook
+    :param sentry_dsn: the Sentry DSN
+    :param release: the release name to tag events with
+    :param host_id: some str representing the host this service is running on
+    :param integrations: list of sentry integrations to set up;
+    :param before_send: set this to a callable to handle the Sentry before_send hook
 
         For scrubbing, do something like this::
 
@@ -42,7 +42,7 @@ def set_up_sentry(
 
         and then pass that as the ``before_send`` value.
 
-    :arg kwargs: any additional arguments to pass to sentry_sdk.init()
+    :param kwargs: any additional arguments to pass to sentry_sdk.init()
 
     """
     if not sentry_dsn:

--- a/src/fillmore/scrubber.py
+++ b/src/fillmore/scrubber.py
@@ -325,7 +325,7 @@ class Scrubber:
         error_handler: Optional[Callable] = None,
     ):
         """
-        :arg rules: list of Rule instances
+        :param rules: list of Rule instances
         :param error_handler: function that takes a msg (str) and is called
             when either a scrub rule or getting the specified key by path in the
             Sentry event kicks up an error; this lets you emit some kind of signal


### PR DESCRIPTION
This fixes API docs by fixing the reST errors as well as changing
`:arg:` to `:param:` which works better.