### PR TITLE
Handle paths that have no target (#12)

### DIFF
--- a/src/fillmore/scrubber.py
+++ b/src/fillmore/scrubber.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Generator, List, Optional, Union
 import attrs
 
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 MASK_TEXT: str = "[Scrubbed]"
@@ -300,6 +300,10 @@ def _get_target_dicts(event: dict, path: List[str]) -> Generator[dict, None, Non
         elif part in parent:
             parent = parent[part]
 
+        else:
+            # This path doesn't point to a thing in the structure
+            return
+
     if isinstance(parent, dict):
         yield parent
 
@@ -366,12 +370,12 @@ class Scrubber:
                             filtered_val = rule.scrub(val)
                         except Exception as inner_exc:
                             msg = f"scrub fun error: {rule.scrub.__name__}, error: {inner_exc}"
-                            logger.exception(msg)
+                            LOGGER.exception(msg)
                             if self.error_handler is not None:
                                 try:
                                     self.error_handler(msg)
                                 except Exception:
-                                    logger.exception(
+                                    LOGGER.exception(
                                         f"error in error_handler {self.error_handler.__name__}"
                                     )
 
@@ -381,12 +385,12 @@ class Scrubber:
 
             except Exception as outer_exc:
                 msg = f"scrubber error: error: {outer_exc}"
-                logger.exception(msg)
+                LOGGER.exception(msg)
                 if self.error_handler is not None:
                     try:
                         self.error_handler(msg)
                     except Exception:
-                        logger.exception(
+                        LOGGER.exception(
                             f"error in error_handler {self.error_handler.__name__}"
                         )
 

--- a/src/fillmore/test.py
+++ b/src/fillmore/test.py
@@ -17,7 +17,7 @@ from sentry_sdk.transport import Transport
 from fillmore.scrubber import Scrubber
 
 
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def get_sentry_base_url(sentry_dsn: str) -> str:
@@ -27,9 +27,16 @@ def get_sentry_base_url(sentry_dsn: str) -> str:
 
     :param sentry_dsn: the sentry base url
 
+    :raises TypeError: when sentry_dsn is not a string
+
+    :raises ValueError: when sentry_dsn is empty
+
     """
+    if not isinstance(sentry_dsn, str):
+        raise TypeError("sentry_dsn must be a str")
+
     if not sentry_dsn:
-        raise Exception("sentry_dsn required")
+        raise ValueError("sentry_dsn is required")
 
     parsed_dsn = urlparse(sentry_dsn)
     netloc = parsed_dsn.netloc
@@ -181,6 +188,6 @@ class SaveEvents:
             data = json.dumps(event)
             path.write_text(data)
         except Exception as exc:
-            logger.exception(f"error in SaveEvents.__call__: {exc}")
+            LOGGER.exception(f"error in SaveEvents.__call__: {exc}")
 
         return self.wrapped_scrubber(event=event, hint=hint)

--- a/tests/test_scrubber.py
+++ b/tests/test_scrubber.py
@@ -219,6 +219,21 @@ def test_get_target_paths(event, path, expected):
     assert list(_get_target_dicts(event, path)) == expected
 
 
+@pytest.mark.parametrize(
+    "event, path, expected",
+    [
+        # Test case where path points to item not in structure
+        (
+            {"exception": {"values": [{"foo": "bar"}]}},
+            ["exception", "values", "[]", "stacktrace", "frames", "[]", "values"],
+            [],
+        )
+    ],
+)
+def test_get_target_paths_missing(event, path, expected):
+    assert list(_get_target_dicts(event, path)) == expected
+
+
 class TestScrubber:
     @pytest.mark.parametrize(
         "rules, event, expected",


### PR DESCRIPTION
This fixes the handling for scrubber paths that are valid, but don't point to something in the structure. Previously, it erroneously kicked up a `RulePathError`. Now it works as expected.

Fixes #12