### PR TITLE
Add support for python 3.11 and django 4.1 (#18)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     name: Python ${{ matrix.python-version}}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PROJECT=fillmore
 .PHONY: help
 help:
 	@echo "Available rules:"
+	@echo ""
 	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:  /'
 
 .PHONY: test
@@ -12,12 +13,13 @@ test:  ## Run tests
 
 .PHONY: typecheck
 typecheck:  ## Run typechecking
-	mypy src/${PROJECT}/
+	tox -e py38-typecheck
 
 .PHONY: lint
 lint:  ## Lint and reformat files
-	black --target-version=py38 --line-length=88 setup.py src tests docs examples
-	flake8 setup.py src tests docs examples
+	black --check --target-version=py38 --line-length=88 setup.py src tests docs examples
+	tox -e py38-black
+	tox -e py38-flake8
 
 .PHONY: clean
 clean:  ## Clean build artifacts

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
 # Requirements for GitHub actions CI
-tox==3.25.1
-tox-gh-actions==2.9.1
+tox==3.27.0
+tox-gh-actions==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,10 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,23 @@
 [tox]
-envlist = py{38,39,310}-django{none,32,40},py38-flake8,py38-black,py38-typecheck,py38-examples
+envlist = py{38,39,310}-django{none,32,40,41},
+    py311-django{none,41},
+    py38-flake8,
+    py38-black,
+    py38-typecheck,
+    py38-examples
 
 [gh-actions]
 python =
-    3.8: py38-djangonone, py38-django32, py38-django40, py38-black, py38-flake8, py38-typecheck, py38-examples
-    3.9: py39-djangonone, py39-django32, py39-django40
-    3.10: py310-djangonone, py310-django32, py310-django40
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     -rrequirements-dev.txt
 commands =
     {posargs:pytest tests/}
@@ -34,4 +41,3 @@ commands = flake8 setup.py src tests docs examples
 basepython = python3.8
 changedir = {toxinidir}
 commands = mypy src/fillmore/
-


### PR DESCRIPTION
This adds support for Python 3.11 and while I was doing that, I added support for Django 4.1. I also adjusted the tox.ini and Makefile files to make it easier to maintain them going forward.

Fixes #18