### PR TITLE
implement diff_event (#23)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ deps =
     django41: Django>=4.1,<4.2
     -rrequirements-dev.txt
 commands =
-    {posargs:pytest tests/}
+    pytest tests/ {posargs}
 
 [testenv:py38-lint]
 basepython = python3.8

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -2,12 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from unittest.mock import ANY
+
 import pytest
 import sentry_sdk
 from sentry_sdk.integrations.stdlib import StdlibIntegration
 
 from fillmore.scrubber import Scrubber, Rule
-from fillmore.test import SentryTestHelper, get_sentry_base_url
+from fillmore.test import SentryTestHelper, get_sentry_base_url, diff_event
 
 
 @pytest.mark.parametrize(
@@ -183,3 +185,172 @@ def test_capture_events_with_scrubber():
         assert error["value"] == "intentional"
         # Verify the username frame-local var is scrubbed
         assert error["stacktrace"]["frames"][0]["vars"]["username"] == "[Scrubbed]"
+
+
+class Test_diff_event:
+    @pytest.mark.parametrize(
+        "a",
+        [
+            None,
+            "",
+            "abc",
+            5,
+            5.5,
+            [1, 2, 3],
+            {"a": "b"},
+        ],
+    )
+    def test_basic_equals(self, a):
+        assert diff_event(a, a) == []
+
+    @pytest.mark.parametrize(
+        "a, b",
+        [
+            (ANY, [1, 2, 3]),
+            ([1, ANY, 3], [1, 2, 3]),
+            (ANY, {"a": "b"}),
+            ({"a": ANY}, {"a": [1, 2, 3]}),
+        ],
+    )
+    def test_any(self, a, b):
+        assert diff_event(a, b) == []
+        assert diff_event(b, a) == []
+
+    def test_different_types(self):
+        assert diff_event(1, "a") == [
+            {
+                "a": 1,
+                "b": "a",
+                "path": "",
+                "msg": "different types a:<class 'int'> b:<class 'str'>",
+            }
+        ]
+
+    def test_deep(self):
+        event = {
+            "mechanism": {
+                "handled": True,
+                "type": "generic",
+            },
+            "stack": [
+                {
+                    "file": "some/path.py",
+                    "in_app": True,
+                    "line": 55,
+                    "pre_context": "some string",
+                },
+                {
+                    "file": "some/other/path.py",
+                    "in_app": True,
+                    "line": 42,
+                    "pre_context": "some other string",
+                },
+            ],
+            "modules": ["a", "b", "c"],
+            "context": {
+                "python": "3.9.12",
+                "build": "42",
+            },
+        }
+        expected_event = {
+            "mechanism": None,
+            "stack": [
+                {
+                    "file": "some/path.py",
+                    "line": ANY,
+                    "pre_context": ANY,
+                    "meta": True,
+                },
+                {
+                    "file": "some/other/path_elsewhere.py",
+                    "line": ANY,
+                    "pre_context": "some other string",
+                    "meta": True,
+                },
+            ],
+            "modules": ANY,
+            "context": {
+                "python": ANY,
+                "build": ANY,
+            },
+        }
+
+        differences = diff_event(event, expected_event)
+        assert differences == [
+            {
+                "msg": "different types a:<class 'dict'> b:<class 'NoneType'>",
+                "path": ".mechanism",
+                "a": {"handled": True, "type": "generic"},
+                "b": None,
+            },
+            {
+                "msg": "in_app in a, not in b",
+                "path": ".stack.[0]",
+                "a": {
+                    "file": "some/path.py",
+                    "in_app": True,
+                    "line": 55,
+                    "pre_context": "some string",
+                },
+                "b": {
+                    "file": "some/path.py",
+                    "line": ANY,
+                    "pre_context": ANY,
+                    "meta": True,
+                },
+            },
+            {
+                "msg": "meta in b, not in a",
+                "path": ".stack.[0]",
+                "a": {
+                    "file": "some/path.py",
+                    "in_app": True,
+                    "line": 55,
+                    "pre_context": "some string",
+                },
+                "b": {
+                    "file": "some/path.py",
+                    "line": ANY,
+                    "pre_context": ANY,
+                    "meta": True,
+                },
+            },
+            {
+                "msg": "'some/other/path.py' != 'some/other/path_elsewhere.py'",
+                "path": ".stack.[1].file",
+                "a": "some/other/path.py",
+                "b": "some/other/path_elsewhere.py",
+            },
+            {
+                "msg": "in_app in a, not in b",
+                "path": ".stack.[1]",
+                "a": {
+                    "file": "some/other/path.py",
+                    "in_app": True,
+                    "line": 42,
+                    "pre_context": "some other string",
+                },
+                "b": {
+                    "file": "some/other/path_elsewhere.py",
+                    "line": ANY,
+                    "pre_context": "some other string",
+                    "meta": True,
+                },
+            },
+            {
+                "msg": "meta in b, not in a",
+                "path": ".stack.[1]",
+                "a": {
+                    "file": "some/other/path.py",
+                    "in_app": True,
+                    "line": 42,
+                    "pre_context": "some other string",
+                },
+                "b": {
+                    "file": "some/other/path_elsewhere.py",
+                    "line": ANY,
+                    "pre_context": "some other string",
+                    "meta": True,
+                },
+            },
+        ]


### PR DESCRIPTION
This implements a utility function for comparing two Sentry events. It's helpful when writing tests to verify that the event generated by Sentry is the same as some expected structure. It handles `unittest.mock.ANY` allowing you to gloss over parts of the event structure (for example, event ids which always change).

Fixes #23.