### PR TITLE
Fix clear_breadcrumbs call (#51)

### DIFF
--- a/src/fillmore/test.py
+++ b/src/fillmore/test.py
@@ -157,7 +157,7 @@ class SentryTestHelper:
         self._transport.reset()
 
         # Clear the breadcrumbs in the scope
-        sentry_sdk.Hub.current.scope.clear_breadcrumbs()
+        sentry_sdk.Scope.get_current_scope().clear_breadcrumbs()
 
         # Mock the transport with one that captures events
         with patch.object(client, attribute="transport", new=self._transport):


### PR DESCRIPTION
This fixes SentryTestHelper.reuse so that it clears the breadcrumbs with sentry_sdk >=2.